### PR TITLE
feat: Enable chained image operations and improve UX

### DIFF
--- a/templates/edit.html
+++ b/templates/edit.html
@@ -3,32 +3,44 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Edit Image - {{ filename }}</title>
+    <title>Edit Image - {{ current_filename_for_processing }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <style>
         .image-container {
             display: flex;
-            justify-content: space-around;
-            align-items: flex-start;
+            justify-content: space-around; /* Distributes space between and around content items */
+            align-items: flex-start; /* Align items to the top */
+            flex-wrap: wrap; /* Allow items to wrap to the next line on smaller screens */
             margin-top: 20px;
         }
         .image-box {
             border: 1px solid #ccc;
             padding: 10px;
             text-align: center;
+            margin: 10px; /* Add some margin for spacing when wrapped */
+            flex-basis: 45%; /* Each box takes up to 45% of the container width */
+            box-sizing: border-box; /* Include padding and border in the element's total width and height */
         }
         .image-box img {
-            max-width: 400px;
+            max-width: 100%; /* Make image responsive within its box */
             max-height: 400px;
             height: auto;
             display: block;
             margin-bottom: 10px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+        .processing-info {
+            background-color: #e7f3fe;
+            border-left: 6px solid #2196F3;
+            padding: 10px;
+            margin-bottom: 15px;
         }
     </style>
 </head>
 <body>
     <header>
-        <h1>Edit Image: {{ filename }}</h1>
+        <h1>Edit Image: {{ current_filename_for_processing }}</h1>
         <p><a href="{{ url_for('index') }}">Upload Another Image</a></p>
     </header>
     <main>
@@ -44,10 +56,18 @@
 
         <div class="editor-toolbar">
             <h2>Processing Tools</h2>
-            <form action="{{ url_for('enhance_image_route', filename=filename) }}" method="POST" style="display: inline;">
+            <p class="processing-info">
+                Operations will be applied to the image shown below: <strong>{{ current_filename_for_processing }}</strong>.
+                {% if is_processed_image %}
+                    This is a processed image. Further operations will build upon this version.
+                {% else %}
+                    This is the original uploaded image.
+                {% endif %}
+            </p>
+            <form action="{{ url_for('enhance_image_route', source_filename=current_filename_for_processing) }}" method="POST" style="display: inline;">
                 <button type="submit">Auto-Enhance (Contrast)</button>
             </form>
-            <form action="{{ url_for('remove_bg_route', filename=filename) }}" method="POST" style="display: inline;">
+            <form action="{{ url_for('remove_bg_route', source_filename=current_filename_for_processing) }}" method="POST" style="display: inline;">
                 <button type="submit">Remove Background (Placeholder)</button>
             </form>
             <!-- Add more processing buttons here -->
@@ -55,17 +75,25 @@
 
         <div class="image-container">
             <div class="image-box">
-                <h3>Original Image</h3>
-                <img src="{{ uploaded_image_url }}" alt="Original Image: {{ filename }}">
+                <h3>Current Image for Processing</h3>
+                <img src="{{ display_image_url }}" alt="Image: {{ current_filename_for_processing }}">
+                <p>Filename: {{ current_filename_for_processing }}</p>
+                <p><a href="{{ display_image_url }}" download="{{ current_filename_for_processing }}">Download This Image</a></p>
             </div>
-            {% if processed_image_url %}
-            <div class="image-box">
-                <h3>Processed Image</h3>
-                <img src="{{ processed_image_url }}" alt="Processed Image: {{ processed_filename }}">
-                <p><a href="{{ processed_image_url }}" download="{{ processed_filename }}">Download Processed Image</a></p>
-            </div>
-            {% endif %}
         </div>
+
+        <!-- Optional: Could add a section to show the original uploaded image if current_filename_for_processing is a processed one -->
+        <!-- For example:
+        {% if is_processed_image and original_uploaded_filename %}
+        <div class="image-container" style="margin-top: 30px; border-top: 1px dashed #ccc; padding-top:20px;">
+            <div class="image-box">
+                <h4>Original Uploaded Image Reference</h4>
+                <img src="{{ url_for('display_uploaded_file', filename=original_uploaded_filename) }}" alt="Original Uploaded Image">
+                <p>Filename: {{ original_uploaded_filename }}</p>
+            </div>
+        </div>
+        {% endif %}
+        -->
     </main>
     <footer>
         <p>&copy; 2023 Photo Editor</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,8 +28,8 @@
             {% endwith %}
         </div>
         <div class="preview-section">
-            <h2>Preview</h2>
-            <img id="imagePreview" src="#" alt="Image Preview" style="display:none; max-width: 100%; height: auto;">
+            <h2>Client-Side Preview</h2>
+            <img id="imagePreview" src="#" alt="Your image will appear here" style="display:none; max-width: 100%; max-height: 300px; height: auto; margin-top:10px; border: 1px solid #ddd;">
         </div>
         <div class="editor-toolbar">
             <h2>Edit Tools</h2>


### PR DESCRIPTION
- Implemented chaining of image processing operations, allowing users to apply multiple edits sequentially to an image.
- Processing actions now operate on the currently displayed image (original or previously processed version).
- Filenames for processed images are generated to reflect the sequence of operations and include a counter to prevent overwrites for repeated actions.
- Re-activated and verified client-side image preview on the main upload page (`index.html`) for better UX.
- Enhanced clarity on the `edit.html` page:
    - The page now clearly indicates which image (original or processed) is the current target for operations.
    - Consolidated image display to show only the current working image.
- Refactored `app.py` to simplify edit routes and improve logic for handling source images from different folders (uploads/processed).